### PR TITLE
feat: Expense Limit Confirmation

### DIFF
--- a/src/main/java/site/easy/to/build/crm/controller/ExpenseController.java
+++ b/src/main/java/site/easy/to/build/crm/controller/ExpenseController.java
@@ -97,19 +97,29 @@ public class ExpenseController {
             @RequestParam("description") String description,
             @RequestParam("amount") double amount,
             @RequestParam("date") String dateString,
+            @RequestParam(name = "confirm", required = false) String confirm,
             Model model) {
 
         try {
             LocalDate date = LocalDate.parse(dateString);
 
             LeadExpense leadExpense = new LeadExpense();
-            Lead lead = new Lead();
-            lead.setLeadId(leadId);
+            Lead lead = leadService.findByLeadId(leadId);
 
             leadExpense.setLead(lead);
             leadExpense.setDescription(description);
             leadExpense.setAmount(amount);
             leadExpense.setDate(date);
+
+            Integer customerId = lead.getCustomer().getCustomerId();
+            boolean budgetIsExceeded = expenseService.checkIfBudgetIsExceeded(customerId, amount);
+
+            if (budgetIsExceeded && confirm == null) {
+                model.addAttribute("leadToUpdate", lead);
+                model.addAttribute("leadExpense", leadExpense);
+                model.addAttribute("confirmation", "Adding this expense would exceed the customer's budget");
+                return "expense/lead-form";
+            }
 
             leadExpenseService.createLeadExpense(leadExpense);
 

--- a/src/main/java/site/easy/to/build/crm/service/expense/ExpenseService.java
+++ b/src/main/java/site/easy/to/build/crm/service/expense/ExpenseService.java
@@ -95,4 +95,26 @@ public class ExpenseService {
                 })
                 .toList();
     }
+
+    /**
+     * Checks if adding a new expense amount to the customer's total expenses would
+     * exceed their budget.
+     *
+     * @param customerId       The ID of the customer.
+     * @param newExpenseAmount The amount of the new expense.
+     * @return true if the new expense would exceed the budget, false otherwise.
+     */
+    public boolean checkIfBudgetIsExceeded(Integer customerId, double newExpenseAmount) {
+        Customer customer = customerService.findByCustomerId(customerId);
+        if (customer == null) {
+            return false;
+        }
+
+        double customerBudget = customerBudgetService.getBudgetByCustomerId(customerId);
+        double totalLeadExpenses = leadExpenseService.getLeadExpenseByCustomerId(customerId);
+        double totalTicketExpenses = ticketExpenseService.getTicketExpenseByCustomerId(customerId);
+
+        double totalExpenses = totalLeadExpenses + totalTicketExpenses;
+        return (totalExpenses + newExpenseAmount) > customerBudget;
+    }
 }

--- a/src/main/resources/templates/expense/lead-form.html
+++ b/src/main/resources/templates/expense/lead-form.html
@@ -83,12 +83,19 @@
                                     Warning: Customer's expense threshold has been reached.
                                 </div>
 
+                                <div th:if="${confirmation != null}" class="alert alert-warning" role="alert">
+                                    <span th:text="${confirmation}"></span>
+                                </div>
+
                                 <form
-                                    th:action="${leadExpense?.leadExpenseId != null} ? @{/expenses/leads/update} : @{/expenses/leads}"
+                                    th:action="${confirmation == null && leadExpense?.leadExpenseId != null} ? @{/expenses/leads/update} : @{/expenses/leads}"
                                     method="post">
                                     <input type="hidden" name="leadExpenseId"
                                         th:if="${leadExpense?.leadExpenseId != null}"
                                         th:value="${leadExpense?.leadExpenseId}" />
+
+                                    <input type="hidden" name="confirm" th:if="${confirmation != null}"
+                                        th:value="Confirm" />
 
                                     <div th:if="${leadToUpdate == null}">
                                         <label class="m-t-20" for="leadId">Lead:</label>
@@ -131,9 +138,11 @@
                                     </div>
 
                                     <button type="submit" class="btn btn-primary m-t-20"
-                                        th:text="${leadExpense?.leadExpenseId != null} ? 'Update Lead Expense' : 'Create Lead Expense'">
+                                        th:text="${confirmation != null} ? 'Confirm' : (${leadExpense?.leadExpenseId != null} ? 'Update Lead Expense' : 'Create Lead Expense')">
                                         Create Lead Expense
                                     </button>
+                                    <a th:if="${confirmation != null}" th:href="@{/expenses/leads}"
+                                        class="btn btn-secondary m-t-20">Cancel</a>
                                 </form>
                             </div>
                         </div>

--- a/src/main/resources/templates/expense/ticket-form.html
+++ b/src/main/resources/templates/expense/ticket-form.html
@@ -83,12 +83,19 @@
                                     Warning: Customer's expense threshold has been reached.
                                 </div>
 
+                                <div th:if="${confirmation != null}" class="alert alert-warning" role="alert">
+                                    <span th:text="${confirmation}"></span>
+                                </div>
+
                                 <form
-                                    th:action="${ticketExpense?.ticketExpenseId != null} ? @{/expenses/tickets/update} : @{/expenses/tickets}"
+                                    th:action="${confirmation == null && ticketExpense?.ticketExpenseId != null} ? @{/expenses/tickets/update} : @{/expenses/tickets}"
                                     method="post">
                                     <input type="hidden" name="ticketExpenseId"
                                         th:if="${ticketExpense?.ticketExpenseId != null}"
                                         th:value="${ticketExpense?.ticketExpenseId}" />
+
+                                    <input type="hidden" name="confirm" th:if="${confirmation != null}"
+                                        th:value="Confirm" />
 
                                     <div th:if="${ticketToUpdate == null}">
                                         <label class="m-t-20" for="ticketId">Ticket:</label>
@@ -133,9 +140,12 @@
                                     </div>
 
                                     <button type="submit" class="btn btn-primary m-t-20"
-                                        th:text="${ticketExpense?.ticketExpenseId != null} ? 'Update Ticket Expense' : 'Create Ticket Expense'">
+                                        th:text="${confirmation != null} ? 'Confirm' : (${ticketExpense?.ticketExpenseId != null} ? 'Update Ticket Expense' : 'Create Ticket Expense')">
                                         Create Ticket Expense
                                     </button>
+
+                                    <a th:if="${confirmation != null}" th:href="@{/expenses/tickets}"
+                                        class="btn btn-secondary m-t-20">Cancel</a>
                                 </form>
                             </div>
                         </div>


### PR DESCRIPTION
## Overview

This pull request enhances the expense management feature by adding budget limit confirmation functionality. This ensures that users are prompted for confirmation when attempting to create or update expenses that exceed the customer's budget, preventing accidental overspending.

## Changes made

* Implemented budget limit checks for both lead and ticket expense forms, prompting users for confirmation if expenses exceed the customer's budget.
* Modified the expense forms to handle budget-exceeded confirmation, redirecting users back to the form for confirmation before finalizing the expense entry.
* Added a service method to determine if a given expense exceeds the customer's budget.
